### PR TITLE
build: add CMake build for C++ app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+project(student_info_docker LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(student_app src/main.cpp)
+target_include_directories(student_app PRIVATE include)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,1 +1,13 @@
 // entry point (placeholder)
+#include <iostream>
+
+int main() {
+    std::cout << "Student Info System - C++ App\n";
+    return 0;
+}
+#include <iostream>
+
+int main() {
+    std::cout << "Student Info System - C++ App\n";
+    return 0;
+}


### PR DESCRIPTION
Adds minimal CMake-based build setup for the C++ application to support the Docker build process.
