### PR TITLE
config: define database environment variables for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,18 @@ This project is licensed under the MIT License.
 ## C++ (Develop)
 C++ development happens on the `develop` branch via PRs.
 
+## Database Environment Variables
+
+The application uses the following environment variables for database configuration
+when running inside Docker:
+
+- DB_HOST
+- DB_PORT
+- DB_NAME
+- DB_USER
+- DB_PASSWORD
+
+These variables are defined in the docker-compose.yml file and no credentials
+are hardcoded in the application.
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,11 @@ services:
 
 volumes:
   pgdata:
+environment:
+  DB_HOST: postgres
+  DB_PORT: 5432
+  DB_NAME: student_db
+  DB_USER: student_user
+  DB_PASSWORD: student_password
 
  


### PR DESCRIPTION
## Description
Defines DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD for Docker/Docker Compose usage.

## Tasks
- Define DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
- Ensure no hardcoded credentials exist
- Document configuration in README

## Notes
Values are example defaults; credentials are provided via environment variables.
