### PR TITLE
docs: add Docker Hub image link for PostgreSQL (Week 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,15 @@ This repository includes a C++ CLI application responsible for
 managing student information and communicating with a PostgreSQL database.
 
 
+## Docker Images
+
+### PostgreSQL (Week 2)
+
+Docker Hub image:
+https://hub.docker.com/r/sudeulufer/student-postgres
+
+Tag:
+- week2
+
+
 


### PR DESCRIPTION
Added Docker Hub link for PostgreSQL image built in Week 2.

Image:
- sudeulufer/student-postgres:week2